### PR TITLE
53179 Update chartiq library and simulator urls

### DIFF
--- a/example/lib/data/api_const.dart
+++ b/example/lib/data/api_const.dart
@@ -1,5 +1,5 @@
 class ApiConst {
-  static const String hostSimulator = 'https://mobile-simulator.chartiq.com';
+  static const String hostSimulator = 'https://simulator.chartiq.com';
   static const String hostSymbols = 'https://symbols.chartiq.com';
   static const String defaultExtended = '1';
   static const String defaultMaxResult = '50';

--- a/example/lib/screen/home/main_page.dart
+++ b/example/lib/screen/home/main_page.dart
@@ -26,7 +26,7 @@ class MainPage extends StatefulWidget {
 class _MainPageState extends State<MainPage> {
   late final StreamSubscription<bool> internetSubscription;
   bool previousInternetAvailability = true;
-  final String _chartIQUrl = 'https://mobile.demo.chartiq.com/android/3.5.0/sample-template-native-sdk.html';
+  final String _chartIQUrl = 'https://mobile.demo.chartiq.com/android/3.6.0/sample-template-native-sdk.html';
 
   Offset? _exitFullScreenButtonLastOffset;
 


### PR DESCRIPTION
Note that this project uses the charting library at 'https://mobile.demo.chartiq.com/android/3.6.0/sample-template-native-sdk.html' for both iOS and Android. They both use the same constant.