### PR TITLE
52738-arabic-locale-issues

### DIFF
--- a/example/lib/data/model/chartiq_language_enum.dart
+++ b/example/lib/data/model/chartiq_language_enum.dart
@@ -11,7 +11,7 @@ enum ChartIQLanguage {
   hu("Hungarian", "hu", "HU"),
   zh("Chinese", "zh", "CN"),
   ja("Japanese", "ja", "JP"),
-  ar("Arabic", "ar", "EG");
+  ar("Arabic", "ar", "EG-u-nu-latn");
 
   final String name, languageCode, countryCode;
 


### PR DESCRIPTION
https://chartiq.kanbanize.com/ctrl_board/15/cards/52738/details/

Change the locale from 'ar-EG' to 'ar-EG-u-nu-latn' to address the x-axis date format issues and the y-axis number display for Arabic