### PR TITLE
52796 SignalIQ encoding

### DIFF
--- a/lib/src/model/signal/signal.dart
+++ b/lib/src/model/signal/signal.dart
@@ -59,10 +59,10 @@ class Signal {
 
   Map<String, dynamic> toJson() => {
         'uniqueId': uniqueId,
-        'name': Uri.encodeComponent(name),
+        'name': name,
         'conditions': List<dynamic>.from(conditions.map((x) => x.toJson())),
         'joiner': joiner.value,
-        'description': Uri.encodeComponent(description),
+        'description': description,
         'disabled': disabled,
         'study': study.toJson(),
       };


### PR DESCRIPTION
Resolves, https://chartiq.kanbanize.com/ctrl_board/15/cards/52796/details/


Issue: SignalIQ name and description fields are showing encoded characters on the chart.

Solution: Remove encoding for name and description when converted to JSON. 

When the signal is converted to a json string in order to processed by the android/ios sdk, the name and description are being double encoded. Thus when the signal is decoded by the native bridge, the first layer of encoding is removed, but the characters are still encoded and show on the plot legend and tooltips.

